### PR TITLE
making some changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -127,7 +127,7 @@ module.exports = {
         'no-extend-native': 'error',
         'no-extra-bind': 'error',
         'no-extra-label': 'error',
-        'no-extra-parens': 'error',
+        'no-extra-parens': 'off',
         'no-floating-decimal': 'error',
         'no-implicit-coercion': 'error',
         'no-implicit-globals': 'off',

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ router
 exports default {
   fetch: (request, ...args) => router
                                  .handle(request, ...args)
-                                 .catch(err => {
+                                 .catch(async err => {
                                    // do something fancy with the error
                                    await logTheErrorSomewhere({
                                      url: request.url,
@@ -333,8 +333,7 @@ exports default {
 
 // GET /accidental
 500 {
-  error: 'Cannot find "this" of undefined...',
-  stack: 'Cannot find "this" of undefined blah blah blah on line 6...',
+  error: 'Internal Serverless Error',
   status: 500,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -358,3 +358,6 @@ These folks are the real heroes, making open source the powerhouse that it is!  
 
 #### Core, Concepts, and Codebase
 - [@mvasigh](https://github.com/mvasigh) - for constantly discussing these ridiculously-in-the-weeds topics with me.  And then for writing the TS interfaces (or simply re-writing in TS), right Mehdi??
+
+#### Fixes & Docs
+- [@rubnogueira](https://github.com/rubnogueira)

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ router.get('/plaintext', () => text('OK!'))
 ### Routers
 
 #### `ThrowableRouter(options?: object): Proxy` <a id="throwablerouter"></a>
-This is a convenience wrapper around [itty-router](https://www.npmjs.com/package/itty-router) that simply adds automatic exception handling (with automatic response), rather than requiring `try/catch` blocks within your middleware/handlers, or manually calling a `.catch(error)` on the `router.handle`. **For more elaborate error handling, such as logging errors before a response, [use Router from itty-router (see example)](#advanced-error-handling).**
+This is a convenience wrapper around [itty-router](https://www.npmjs.com/package/itty-router) that simply adds automatic exception handling (with automatic response), rather than requiring `try/catch` blocks within your middleware/handlers, or manually calling a `.catch(error)` on the `router.handle`. **For more elaborate error handling, such as logging errors before a response, [use the core Router from itty-router (see example)](#advanced-error-handling).**
 ```js
 import { ThrowableRouter, StatusError } from 'itty-router-extras'
 
@@ -305,7 +305,7 @@ exports default {
 ```
 
 ### Advanced Error Handling
-Once you need to control more elaborate error handling, simply ditch `ThrowableRouter` (because it will catch before you can ;), and add your own `.catch(err)` to the core itty `Router` as follows:
+Once you need to control more elaborate error handling, simply ditch `ThrowableRouter` (because it will catch and respond before you can), and add your own `.catch(err)` to the core itty `Router` as follows:
 ```js
 import { Router } from 'itty-router'
 import { error } from 'itty-router-extras'

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "itty-router-extras",
-  "version": "0.3.0-next.1",
+  "version": "0.3.0-next.2",
   "description": "An assortment of delicious extras for the calorie-light itty-router.",
-  "main": ".index.js",
+  "main": "./index.js",
   "keywords": [
     "router",
     "cloudflare",
@@ -30,7 +30,7 @@
     "prerelease": "yarn verify",
     "prebuild": "rimraf dist",
     "build": "terser-folder src -eo dist --pattern '**/*.js,!**/*spec.js' -x .js",
-    "release": "release --tag --push"
+    "release": "release --tag --push --src=dist"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-router-extras",
-  "version": "0.3.0-next.0",
+  "version": "0.3.0-next.1",
   "description": "An assortment of delicious extras for the calorie-light itty-router.",
   "main": ".index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,17 +2,12 @@
   "name": "itty-router-extras",
   "version": "0.3.0-next.0",
   "description": "An assortment of delicious extras for the calorie-light itty-router.",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "main": ".index.js",
   "keywords": [
     "router",
     "cloudflare",
     "workers",
     "serverless",
-    "express",
     "regex",
     "routing",
     "api",
@@ -20,10 +15,11 @@
     "params",
     "middleware",
     "nested",
-    "rest",
-    "crud",
-    "query",
-    "paramaters"
+    "helpers",
+    "utils",
+    "cookies",
+    "content",
+    "cors"
   ],
   "scripts": {
     "lint": "npx eslint src",

--- a/src/middleware/withContent.js
+++ b/src/middleware/withContent.js
@@ -7,10 +7,6 @@ const withContent = async request => {
     if (contentType) {
       if (contentType.includes('application/json')) {
         request.content = await request.json()
-      } else if (contentType.includes('application/text')) {
-        request.content = await request.text()
-      } else if (contentType.includes('form')) {
-        request.content = await request.formData()
       }
     }
   } catch (err) {} // silently fail on error

--- a/src/middleware/withContent.spec.js
+++ b/src/middleware/withContent.spec.js
@@ -4,21 +4,24 @@ const { ThrowableRouter } = require('../router/ThrowableRouter')
 const { withContent } = require('./withContent')
 
 describe('middleware/withContent', () => {
-  it('returns with text payload', async () => {
+  it('returns with json payload', async () => {
     const router = ThrowableRouter()
-    const handler = jest.fn(req => req)
+    const handler = jest.fn(req => req.content)
+    const payload = { foo: 'bar' }
 
-    router
-      .post('/', withContent, handler)
+    router.post('/', withContent, handler)
 
     const request = new Request('https://example.com/', {
       method: 'post',
-      body: JSON.stringify({ foo: 'bar' }),
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
     })
 
     await router.handle(request)
 
     expect(handler).toHaveBeenCalled()
-    // expect(handler).toHaveReturnedWith('foo')
+    expect(handler).toHaveReturnedWith(payload)
   })
 })

--- a/src/response/error.js
+++ b/src/response/error.js
@@ -4,12 +4,12 @@ const error = (
   status = 500,
   content = 'Internal Server Error.',
 ) => json({
-  ...typeof content === 'object'
+  ...(typeof content === 'object'
     ? content
     : {
         status,
         error: content,
-      },
+      }),
 }, { status })
 
 module.exports = { error }

--- a/src/response/error.js
+++ b/src/response/error.js
@@ -2,7 +2,12 @@ const { json } = require('./json')
 
 const error = (
   status = 500,
-  message = 'Internal Server Error.',
-) => json({ error: message, status }, { status })
+  content = 'Internal Server Error.',
+) => json({
+  status,
+  ...typeof content === 'object'
+    ? content
+    : { error: content },
+}, { status })
 
 module.exports = { error }

--- a/src/response/error.js
+++ b/src/response/error.js
@@ -4,10 +4,12 @@ const error = (
   status = 500,
   content = 'Internal Server Error.',
 ) => json({
-  status,
   ...typeof content === 'object'
     ? content
-    : { error: content },
+    : {
+        status,
+        error: content,
+      },
 }, { status })
 
 module.exports = { error }

--- a/src/response/error.spec.js
+++ b/src/response/error.spec.js
@@ -20,7 +20,7 @@ describe('response/error', () => {
 
       expect(response instanceof Response).toBe(true)
       expect(response.status).toBe(400)
-      expect(await response.json()).toEqual({ status: 400, ...expected })
+      expect(await response.json()).toEqual(expected)
     })
   })
 })

--- a/src/response/error.spec.js
+++ b/src/response/error.spec.js
@@ -13,5 +13,14 @@ describe('response/error', () => {
       expect(response.status).toBe(400)
       expect(await response.json()).toEqual({ error: message, status: 400 })
     })
+
+    it('will use second param as object payload if given', async () => {
+      const expected = { message: 'Bad Request', stack: [] }
+      const response = error(400, expected)
+
+      expect(response instanceof Response).toBe(true)
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({ status: 400, ...expected })
+    })
   })
 })

--- a/src/response/missing.js
+++ b/src/response/missing.js
@@ -1,5 +1,5 @@
 const { error } = require('./error')
 
-const missing = (message = 'Not found.', other = {}) => error(404, message, other)
+const missing = (message = 'Not found.') => error(404, message)
 
 module.exports = { missing }

--- a/src/response/missing.js
+++ b/src/response/missing.js
@@ -1,5 +1,5 @@
 const { error } = require('./error')
 
-const missing = (message = 'Not found.') => error(404, message)
+const missing = (message = 'Not found.', other = {}) => error(404, message, other)
 
 module.exports = { missing }

--- a/src/response/missing.spec.js
+++ b/src/response/missing.spec.js
@@ -13,5 +13,14 @@ describe('response/missing', () => {
       expect(response.status).toBe(404)
       expect(await response.json()).toEqual({ error: message, status: 404 })
     })
+
+    it('will use second param as object payload if given', async () => {
+      const payload = { message: 'Bad Request', stack: [] }
+      const response = missing(payload)
+
+      expect(response instanceof Response).toBe(true)
+      expect(response.status).toBe(404)
+      expect(await response.json()).toEqual(payload)
+    })
   })
 })

--- a/src/response/status.js
+++ b/src/response/status.js
@@ -2,7 +2,11 @@ const { json } = require('./json')
 
 const status = (status, message) =>
   message
-  ? json({ message }, { status })
+  ? json({
+      ...typeof message === 'object'
+        ? message
+        : { message },
+    }, { status })
   : new Response(null, { status })
 
 module.exports = { status }

--- a/src/response/status.js
+++ b/src/response/status.js
@@ -3,12 +3,12 @@ const { json } = require('./json')
 const status = (status, message) =>
   message
   ? json({
-      ...typeof message === 'object'
+      ...(typeof message === 'object'
         ? message
         : {
             status,
             message,
-          },
+          }),
     }, { status })
   : new Response(null, { status })
 

--- a/src/response/status.js
+++ b/src/response/status.js
@@ -5,7 +5,10 @@ const status = (status, message) =>
   ? json({
       ...typeof message === 'object'
         ? message
-        : { message },
+        : {
+            status,
+            message,
+          },
     }, { status })
   : new Response(null, { status })
 

--- a/src/response/status.spec.js
+++ b/src/response/status.spec.js
@@ -11,11 +11,22 @@ describe('response/error', () => {
 
       expect(response1 instanceof Response).toBe(true)
       expect(response1.status).toBe(400)
+    })
 
+    it('returns a simple message if given', async () => {
       const response2 = status(204, message)
 
       expect(response2.status).toBe(204)
-      expect(await response2.json()).toEqual({ message })
+      expect(await response2.json()).toEqual({ status: 204, message })
+    })
+
+    it('will use second param as object payload if given', async () => {
+      const payload = { message: 'Bad Request', stack: [] }
+      const response = status(400, payload)
+
+      expect(response instanceof Response).toBe(true)
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual(payload)
     })
   })
 })

--- a/src/router/ThrowableRouter.js
+++ b/src/router/ThrowableRouter.js
@@ -3,12 +3,22 @@
 const { Router } = require('itty-router')
 const { error } = require('../response')
 
-const ThrowableRouter = (options = {}) =>
-  new Proxy(Router(options), {
+const ThrowableRouter = (options = {}) => {
+  const { stack = false } = options
+
+  return new Proxy(Router(options), {
     get: (obj, prop) => (...args) =>
         prop === 'handle'
-        ? obj[prop](...args).catch(err => error(err.status || 500, err.message))
+        ? obj[prop](...args).catch(err => error(
+            err.status || 500,
+            {
+              error: err.message,
+              stack: stack && err.stack || undefined
+            },
+          ))
         : obj[prop](...args)
   })
+}
+
 
 module.exports = { ThrowableRouter }

--- a/src/router/ThrowableRouter.js
+++ b/src/router/ThrowableRouter.js
@@ -12,6 +12,7 @@ const ThrowableRouter = (options = {}) => {
         ? obj[prop](...args).catch(err => error(
             err.status || 500,
             {
+              status: err.status || 500,
               error: err.message,
               stack: stack && err.stack || undefined
             },

--- a/src/router/ThrowableRouter.spec.js
+++ b/src/router/ThrowableRouter.spec.js
@@ -1,3 +1,5 @@
+require('isomorphic-fetch')
+
 const { ThrowableRouter } = require('./ThrowableRouter')
 
 describe('router/ThrowableRouter', () => {
@@ -10,6 +12,33 @@ describe('router/ThrowableRouter', () => {
 
       expect(typeof origin.r).toBe('object')
       expect(origin.r.length).toBe(1)
+    })
+
+    it('captures a throw', async () => {
+      const router = ThrowableRouter()
+
+      router.get('/breaks', request => request.will.throw)
+
+      const response = await router.handle(new Request('https://slick/breaks'))
+      const payload = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(payload.error).not.toBeUndefined()
+      expect(payload.status).toBe(500)
+    })
+
+    it('includes a stack trace with option', async () => {
+      const router = ThrowableRouter({ stack: true })
+
+      router.get('/breaks', request => request.will.throw)
+
+      const response = await router.handle(new Request('https://slick/breaks'))
+      const payload = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(payload.error).not.toBeUndefined()
+      expect(payload.stack).not.toBeUndefined()
+      expect(payload.status).toBe(500)
     })
   })
 })

--- a/src/router/ThrowableRouter.spec.js
+++ b/src/router/ThrowableRouter.spec.js
@@ -20,9 +20,11 @@ describe('router/ThrowableRouter', () => {
       router.get('/breaks', request => request.will.throw)
 
       const response = await router.handle(new Request('https://slick/breaks'))
-      const payload = await response.json()
 
       expect(response.status).toBe(500)
+
+      const payload = await response.json()
+
       expect(payload.error).not.toBeUndefined()
       expect(payload.status).toBe(500)
     })

--- a/src/utils/watch.js
+++ b/src/utils/watch.js
@@ -1,5 +1,5 @@
 const watch = (predicate, fn) => request => {
-  request.proxy = new Proxy(request, {
+  request.proxy = new Proxy(request.proxy || request, {
     set: (obj, prop, value) => {
       obj[prop] = value
 

--- a/src/utils/watch.spec.js
+++ b/src/utils/watch.spec.js
@@ -1,0 +1,54 @@
+require('isomorphic-fetch')
+
+const { ThrowableRouter } = require('../router/ThrowableRouter')
+const { watch } = require('./watch')
+
+describe('utils/watch', () => {
+  it('creates reactive middleware (string prop)', async () => {
+    const router = ThrowableRouter()
+    const watcher = jest.fn((value, prop, request) => ({ prop, value }))
+    const handler = jest.fn(req => req.foo)
+
+    const watchFoo = watch('foo', watcher)
+
+    const modifyFoo = request => {
+      request.foo = 'new foo'
+    }
+
+    router
+      .all('*', watchFoo, modifyFoo)
+      .get('/:id', handler)
+
+    const request = new Request('https://example.com/12')
+
+    await router.handle(request)
+
+    expect(handler).toHaveBeenCalled()
+    expect(handler).toHaveReturnedWith('new foo')
+    expect(watcher).toHaveReturnedWith({ prop: 'foo', value: 'new foo' })
+  })
+
+  it('creates reactive middleware (function predicate)', async () => {
+    const router = ThrowableRouter()
+    const watcher = jest.fn((value, prop, request) => ({ prop, value }))
+    const handler = jest.fn(req => req.foo)
+
+    const watchFoo = watch(prop => prop === 'foo', watcher)
+
+    const modifyFoo = request => {
+      request.foo = 'new foo'
+    }
+
+    router
+      .all('*', watchFoo, modifyFoo)
+      .get('/:id', handler)
+
+    const request = new Request('https://example.com/12')
+
+    await router.handle(request)
+
+    expect(handler).toHaveBeenCalled()
+    expect(handler).toHaveReturnedWith('new foo')
+    expect(watcher).toHaveReturnedWith({ prop: 'foo', value: 'new foo' })
+  })
+})


### PR DESCRIPTION
# Changelog
- `withParams` will be useable as upstream middleware:
  ```js
  const router = new Router()
  
  router
    .all('*', withParams) // can put it here now and still get params later
    .get('/:id', ({ id }) => text(`You asked for id: ${id}`))
  ```
- adds `watch(predicate:string|function, callback:function)` to watch and respond to changes on the request
- adds support for custom errors through `error(status:number, content:string|object)`
- adds support for exposing stack trace in errors via `ThrowableRouter({ stack: true })`