### PR TITLE
Fix cookie accumulator

### DIFF
--- a/src/middleware/withCookies.js
+++ b/src/middleware/withCookies.js
@@ -6,8 +6,9 @@ const withCookies = request => {
       .split(/;\s*/)
       .map(pair => pair.split('='))
       .reduce((acc, [key, value]) => {
-        acc[key] = value;
-        return acc;
+        acc[key] = value
+
+return acc
       }, {})
   } catch (err) {}
 }

--- a/src/middleware/withCookies.js
+++ b/src/middleware/withCookies.js
@@ -5,7 +5,7 @@ const withCookies = request => {
     request.cookies = (request.headers.get('Cookie') || '')
       .split(/;\s*/)
       .map(pair => pair.split('='))
-      .reduce((acc, [key, value]) => (acc[key] = value) && acc, {})
+      .reduce((acc, [key, value]) => (acc = {...acc, [key]: value}, {})
   } catch (err) {}
 }
 

--- a/src/middleware/withCookies.js
+++ b/src/middleware/withCookies.js
@@ -8,7 +8,7 @@ const withCookies = request => {
       .reduce((acc, [key, value]) => {
         acc[key] = value
 
-return acc
+        return acc
       }, {})
   } catch (err) {}
 }

--- a/src/middleware/withCookies.js
+++ b/src/middleware/withCookies.js
@@ -5,7 +5,10 @@ const withCookies = request => {
     request.cookies = (request.headers.get('Cookie') || '')
       .split(/;\s*/)
       .map(pair => pair.split('='))
-      .reduce((acc, [key, value]) => (acc = {...acc, [key]: value}, {})
+      .reduce((acc, [key, value]) => {
+        acc[key] = value;
+        return acc;
+      }, {})
   } catch (err) {}
 }
 


### PR DESCRIPTION
Middleware `withCookies` doesn't work as expected when an cookie have a empty value.

```javascript
const test = 'variable1=; variable2=abc';

// Original
test.split(/;\s*/).map(pair => pair.split('=')).reduce((acc, [key, value]) => (acc = {...acc, [key]: value}, {})
// Output: ""


// Fixed
test.split(/;\s*/).map(pair => pair.split('=')).reduce((acc, [key, value]) => (acc = {...acc, [key]: value}), {})
// Output: {variable1: "", variable2: "abc"}
```