### PR TITLE
Typescript Declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.4.2",
   "description": "An assortment of delicious extras for the calorie-light itty-router.",
   "main": "./index.js",
+  "types": "./dist/itty-router-extras.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
   "keywords": [
     "router",
     "cloudflare",
@@ -28,7 +32,7 @@
     "dev": "yarn lint && jest --verbose --watch src",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
     "prerelease": "yarn verify",
-    "prebuild": "rimraf dist",
+    "prebuild": "rimraf dist && mkdir dist && cp src/itty-router-extras.d.ts dist",
     "build": "terser-folder src -eo dist --pattern '**/*.js,!**/*spec.js' -x .js",
     "release": "release --tag --push --src=dist"
   },

--- a/src/itty-router-extras.d.ts
+++ b/src/itty-router-extras.d.ts
@@ -1,0 +1,33 @@
+// Helpers
+
+interface BaseRouterOptions {
+  base?: string;
+}
+
+type ThrowableRouterOptions = BaseRouterOptions & { stack?: boolean };
+
+interface CorsOptions {
+  origin?: string;
+  methods?: string;
+  headers?: string;
+  credentials?: boolean;
+}
+
+export function ThrowableRouter(options?: ThrowableRouterOptions): typeof Proxy;
+
+// Response
+export function json(obj: object): Response;
+export function status(status: number, message: string | object): Response;
+export function error(status?: number, content?: string | object): Response;
+export function missing(message?: string | object): Response;
+export function text(message: string, options?: ResponseInit): Response;
+
+// MiddleWare
+export function withContent(request: Request): void;
+export function withCookies(request: Request): void;
+export function withCors(options?: CorsOptions): Response;
+export function withParams(request: Request): void;
+
+export class StatusError {
+  constructor(status?: number, message?: string);
+}


### PR DESCRIPTION
Types cover public methods, as documented in the readme.

Modifies package.json to support import types, matching how it was done in itty-router.