### PR TITLE
Fixes #17: cookie key-value parsing splits on all "=" rather than just the first "="

### DIFF
--- a/src/middleware/withCookies.js
+++ b/src/middleware/withCookies.js
@@ -4,7 +4,7 @@ const withCookies = request => {
   try {
     request.cookies = (request.headers.get('Cookie') || '')
       .split(/;\s*/)
-      .map(pair => pair.split((/=(.+)/))
+      .map(pair => pair.split(/=(.+)/))
       .reduce((acc, [key, value]) => {
         acc[key] = value
 

--- a/src/middleware/withCookies.js
+++ b/src/middleware/withCookies.js
@@ -4,7 +4,7 @@ const withCookies = request => {
   try {
     request.cookies = (request.headers.get('Cookie') || '')
       .split(/;\s*/)
-      .map(pair => pair.split('='))
+      .map(pair => pair.split((/=(.+)/))
       .reduce((acc, [key, value]) => {
         acc[key] = value
 


### PR DESCRIPTION
Change `.split()` to use a regex that targets only the first occurrence of "="