### PR TITLE
Expose addCorsHeaders

### DIFF
--- a/src/itty-router-extras.d.ts
+++ b/src/itty-router-extras.d.ts
@@ -21,6 +21,7 @@ export function status(status: number, message: string | object): Response;
 export function error(status?: number, content?: string | object): Response;
 export function missing(message?: string | object): Response;
 export function text(message: string, options?: ResponseInit): Response;
+export function addCorsHeaders(request: Request, options?: CorsOptions): (response: Response) => Response;
 
 // MiddleWare
 export function withContent(request: Request): void;

--- a/src/middleware/withCors.js
+++ b/src/middleware/withCors.js
@@ -15,7 +15,7 @@ const withCors = (options = {}) => request => {
   // Handle standard OPTIONS request.
   return new Response(null, {
     headers: {
-      'Allow': `${methods}, HEAD, OPTIONS`,
+      'Allow': `${corsHeaders['Access-Control-Allow-Methods']}, HEAD, OPTIONS`,
     }
   })
 }


### PR DESCRIPTION
This should allow cors headers to be added at the end of a call.

Really, Response middleware (like ThrowableRouter) should be made stackable so we can have CorsRouter.

Maybe something like this?
```js
const router = CorsRouter(corsOptions, ThrowableRouter({ stack: true }, Router({ base: '/' })))
```

Or perhaps:
```js
const router = Router();
...
  event.respondWith(isThrowable(router.handle(event.request)))
```