### PR TITLE
Allow the request to be used in other middleware

### DIFF
--- a/src/middleware/withContent.js
+++ b/src/middleware/withContent.js
@@ -6,7 +6,7 @@ const withContent = async request => {
   try {
     if (contentType) {
       if (contentType.includes('application/json')) {
-        request.content = await request.json()
+        request.content = await request.clone().json()
       }
     }
   } catch (err) {} // silently fail on error


### PR DESCRIPTION
By cloning the request, the request can then be reused in other middleware (makes it easier to clone the request to send to a service binding)